### PR TITLE
Poprawka dla Kodi 18 (Coreelec)

### DIFF
--- a/zips/repository.mbebe/addon.xml
+++ b/zips/repository.mbebe/addon.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <addon id="repository.mbebe" name="mbebe" version="0.1.0" provider-name="mbebe">
-        <requires>
-            <import addon="xbmc.addon" version="12.0.0"/>
-        </requires>
+    <addon id="repository.mbebe" name="mbebe" version="0.1.1" provider-name="mbebe">
         <extension point="xbmc.addon.repository" name="mbebe">
-            <info compressed="false">https://github.com/mbebe/blomqvist/tree/master/zips/addons.xml</info>
-            <checksum>https://github.com/mbebe/blomqvist/tree/master/zips/addons.xml.md5</checksum>
-            <datadir zip="true">https://github.com/mbebe/blomqvist/tree/master/zips/</datadir>
-            <hashes>false</hashes>
+		    <dir>
+                <info compressed="false">https://raw.githubusercontent.com/mbebe/blomqvist/master/zips/addons.xml</info>
+                <checksum>https://raw.githubusercontent.com/mbebe/blomqvist/master/zips/addons.xml.md5</checksum>
+                <datadir zip="true">https://github.com/mbebe/blomqvist/raw/master/zips</datadir>
+            </dir>
         </extension>
         <extension point="xbmc.addon.metadata">
             <summary>...</summary>


### PR DESCRIPTION
Coreelec na kodi 18b3 wymaga poprawnego md5sum dla addon.xml (w poprzendim commicie poprawione) oraz poprawnej struktury - poprzedniej nie odczytywał. Ta jest zgodna z k17 i k18